### PR TITLE
Add detailed allEvents endpoint to the public API

### DIFF
--- a/rcjaRegistration/publicapi/tests.py
+++ b/rcjaRegistration/publicapi/tests.py
@@ -121,6 +121,18 @@ class TestEvents(TestCase):
         self.assertContains(response, 'State 1 Open Workshop')
         self.assertContains(response, 'State 1 Past Competition')
 
+    def testAllEventsDetailedLoads(self):
+        response = self.client.get('/api/v1/public/states/ST1/allEventsDetailed/')
+        self.assertEqual(response.status_code, 200)
+
+    def testAllEventsInAllEventsDetailed(self):
+        response = self.client.get('/api/v1/public/states/ST1/allEventsDetailed/')
+        self.assertContains(response, 'State 1 Open Competition')
+        self.assertContains(response, 'State 1 Closed Competition 1')
+        self.assertContains(response, 'State 1 Closed Competition 2')
+        self.assertContains(response, 'State 1 Open Workshop')
+        self.assertContains(response, 'State 1 Past Competition')
+
     # Upcoming events
 
     def testUpcomingEventsLoads(self):

--- a/rcjaRegistration/publicapi/views.py
+++ b/rcjaRegistration/publicapi/views.py
@@ -58,6 +58,12 @@ class StateViewSet(viewsets.ReadOnlyModelViewSet, NestedSerializerActionMinxin):
         queryset = self.eventsBaseQueryset(abbreviation).order_by('startDate')
         return self.nestedSerializer(queryset, SummaryEventSerializer)
 
+    # Detailed event endpoint
+    @action(detail=True)
+    def allEventsDetailed(self, request, abbreviation=None):
+        queryset = self.eventsBaseQueryset(abbreviation).order_by('startDate')
+        return self.nestedSerializer(queryset, EventSerializer)
+
     # Upcoming events
 
     @action(detail=True)


### PR DESCRIPTION
I've added a new endpoint to the public API at /api/v1/public/states/xxx/allEventsDetailed/. This endpoint expands on the existing /allEvents/ endpoint to provide all past and future events with full detail. 
The new endpoint was created to meet the requirements of the rcja-calendar system, which would benefit from a single endpoint to retrieve fully detailed past and future event information.

I should note that I haven't been able to spin up a local development instance, so this code is untested. Additionally, I'm new to django, so I hope I've done everything correctly. Please check that everything works as intended.