### PR TITLE
Add entersupport email to error messages

### DIFF
--- a/rcjaRegistration/schools/models.py
+++ b/rcjaRegistration/schools/models.py
@@ -36,10 +36,10 @@ class School(SaveDeleteMixin, models.Model):
 
         # Case insenstive abbreviation and name unique check
         if School.objects.filter(name__iexact=self.name).exclude(pk=self.pk).exists():
-            errors.append(ValidationError('School with this name exists. Please ask your school administrator to add you.'))
+            errors.append(ValidationError('School with this name exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'))
 
         if School.objects.filter(abbreviation__iexact=self.abbreviation).exclude(pk=self.pk).exists():
-            errors.append(ValidationError('School with this abbreviation exists. Please ask your school administrator to add you.'))
+            errors.append(ValidationError('School with this abbreviation exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'))
 
         # Validate school not using name or abbreviation reserved for independent entries
         if self.abbreviation.upper() == 'IND':

--- a/rcjaRegistration/schools/tests/tests_legacy.py
+++ b/rcjaRegistration/schools/tests/tests_legacy.py
@@ -291,7 +291,7 @@ class TestSchoolForm(TestCase):
 
         self.assertEqual(form.is_valid(), False)
         self.assertEqual(form.errors["name"], ["School with this Name already exists."])
-        self.assertEqual(form.non_field_errors(), ["School with this name exists. Please ask your school administrator to add you."])
+        self.assertEqual(form.non_field_errors(), ['School with this name exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'])
 
     def testTeamNameDifferentCase(self):
         form = self.createForm({
@@ -303,7 +303,7 @@ class TestSchoolForm(TestCase):
         })
 
         self.assertEqual(form.is_valid(), False)
-        self.assertEqual(form.non_field_errors(), ["School with this name exists. Please ask your school administrator to add you."])
+        self.assertEqual(form.non_field_errors(), ['School with this name exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'])
 
     def testAbbreviationSameCase(self):
         form = self.createForm({
@@ -316,7 +316,7 @@ class TestSchoolForm(TestCase):
 
         self.assertEqual(form.is_valid(), False)
         self.assertEqual(form.errors["abbreviation"], ["School with this Abbreviation already exists."])
-        self.assertEqual(form.non_field_errors(), ["School with this abbreviation exists. Please ask your school administrator to add you."])
+        self.assertEqual(form.non_field_errors(), ['School with this abbreviation exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'])
 
     def testAbbreviationDifferentCase(self):
         form = self.createForm({
@@ -328,7 +328,7 @@ class TestSchoolForm(TestCase):
         })
 
         self.assertEqual(form.is_valid(), False)
-        self.assertEqual(form.non_field_errors(), ["School with this abbreviation exists. Please ask your school administrator to add you."])
+        self.assertEqual(form.non_field_errors(), ['School with this abbreviation exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'])
 
     def testIndependentClean(self):
         form = self.createForm({

--- a/rcjaRegistration/templates/registration/profile.html
+++ b/rcjaRegistration/templates/registration/profile.html
@@ -137,7 +137,7 @@
             <p>If you are the first mentor in you school, create a school by clicking the button below.</p>
             <p>If you are an independent skip this step, you can register teams as an individual.</p>
             <p>If someone else has already registered your school ask them to add you as an administrator.</p>
-            <p>If you don't know who your school administrator is please contact us, please do not create a duplicate school.</p>
+            <p>If you don't know who your school administrator is please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>, please do not create a duplicate school.</p>
             {% endif %}
 
             <a href ="{% url 'schools:create' %}"><button class = "ui button primary">Create school</button></a>


### PR DESCRIPTION
I have added some extra text to the messages regarding school administrators to further direct the user towards the entersupport email instead of creating a school with a different name/acronym.

![image](https://user-images.githubusercontent.com/36472285/230723055-729ae10d-086e-4414-87b6-48c164bcbabb.png)
![image](https://user-images.githubusercontent.com/36472285/230723080-c0f858d7-f6d5-4182-aa51-3f9453527d53.png)
