### PR TITLE
Fix raw HTML showing on errors after #563

### DIFF
--- a/rcjaRegistration/schools/models.py
+++ b/rcjaRegistration/schools/models.py
@@ -36,10 +36,10 @@ class School(SaveDeleteMixin, models.Model):
 
         # Case insenstive abbreviation and name unique check
         if School.objects.filter(name__iexact=self.name).exclude(pk=self.pk).exists():
-            errors.append(ValidationError('School with this name exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'))
+            errors.append(ValidationError('School with this name exists. Please ask your school administrator to add you. If your school administrator has left, please contact us at entersupport@robocupjunior.org.au'))
 
         if School.objects.filter(abbreviation__iexact=self.abbreviation).exclude(pk=self.pk).exists():
-            errors.append(ValidationError('School with this abbreviation exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'))
+            errors.append(ValidationError('School with this abbreviation exists. Please ask your school administrator to add you. If your school administrator has left, please contact us at entersupport@robocupjunior.org.au'))
 
         # Validate school not using name or abbreviation reserved for independent entries
         if self.abbreviation.upper() == 'IND':

--- a/rcjaRegistration/schools/tests/tests_legacy.py
+++ b/rcjaRegistration/schools/tests/tests_legacy.py
@@ -291,7 +291,7 @@ class TestSchoolForm(TestCase):
 
         self.assertEqual(form.is_valid(), False)
         self.assertEqual(form.errors["name"], ["School with this Name already exists."])
-        self.assertEqual(form.non_field_errors(), ['School with this name exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'])
+        self.assertEqual(form.non_field_errors(), ['School with this name exists. Please ask your school administrator to add you. If your school administrator has left, please contact us at entersupport@robocupjunior.org.au'])
 
     def testTeamNameDifferentCase(self):
         form = self.createForm({
@@ -303,7 +303,7 @@ class TestSchoolForm(TestCase):
         })
 
         self.assertEqual(form.is_valid(), False)
-        self.assertEqual(form.non_field_errors(), ['School with this name exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'])
+        self.assertEqual(form.non_field_errors(), ['School with this name exists. Please ask your school administrator to add you. If your school administrator has left, please contact us at entersupport@robocupjunior.org.au'])
 
     def testAbbreviationSameCase(self):
         form = self.createForm({
@@ -316,7 +316,7 @@ class TestSchoolForm(TestCase):
 
         self.assertEqual(form.is_valid(), False)
         self.assertEqual(form.errors["abbreviation"], ["School with this Abbreviation already exists."])
-        self.assertEqual(form.non_field_errors(), ['School with this abbreviation exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'])
+        self.assertEqual(form.non_field_errors(), ['School with this abbreviation exists. Please ask your school administrator to add you. If your school administrator has left, please contact us at entersupport@robocupjunior.org.au'])
 
     def testAbbreviationDifferentCase(self):
         form = self.createForm({
@@ -328,7 +328,7 @@ class TestSchoolForm(TestCase):
         })
 
         self.assertEqual(form.is_valid(), False)
-        self.assertEqual(form.non_field_errors(), ['School with this abbreviation exists. Please ask your school administrator to add you.<br>If your school administrator has left, please contact us at <a href="mailto:entersupport@robocupjunior.org.au?Subject=Update%20School%20Administrator">entersupport@robocupjunior.org.au</a>'])
+        self.assertEqual(form.non_field_errors(), ['School with this abbreviation exists. Please ask your school administrator to add you. If your school administrator has left, please contact us at entersupport@robocupjunior.org.au'])
 
     def testIndependentClean(self):
         form = self.createForm({


### PR DESCRIPTION
This fixes a bug created by https://github.com/robocupjunioraustralia/RCJA_Registration_System/pull/563

Since I have finally managed to get a local dev instance of this to work I was able to test the previous PR, turns out the errors sanitize HTML. I have removed the <a> tag and just made it show the email instead.

Before:
![image](https://user-images.githubusercontent.com/36472285/230777487-f80f04f5-7359-4d7a-a826-8f0f8e81a336.png)

After:
![image](https://user-images.githubusercontent.com/36472285/230777483-44713c60-9158-4607-9a82-50534cd48c90.png)
