### PR TITLE
Remove file comments field & wording changes on file upload page

### DIFF
--- a/rcjaRegistration/templates/eventfiles/uploadMentorEventFile.html
+++ b/rcjaRegistration/templates/eventfiles/uploadMentorEventFile.html
@@ -47,7 +47,7 @@
 
                         {% if not uploadedFile %}
                         <h2>Upload a new file</h2>
-                        <h3 style="color: red">Due to an issue files larger than approximately 10MB currently cannot be uploaded. For larger files please instead submit a sharing link through the notes field on the team.</h3>
+                        <h3 style="color: red">Due to an issue files larger than approximately 10MB currently cannot be uploaded. For larger files please instead submit a sharing link through the notes field on the team.<br/><br/>If you wish to submit a sharing link, please upload a Word or Notepad file with the sharing link inside.</h3>
 
                         {% else %}
                         <h2>Edit existing file: <a href="{{uploadedFile.fileURL}}" target="_blank">{{uploadedFile.originalFilename}}</a></h2>
@@ -103,7 +103,7 @@
                                     {{form.fileUpload}}
                                 </div>
                                 <div class="field">
-                                    <label>Type:</label>
+                                    <label>Category:</label>
                                     {{ form.fileType|attr:"class:ui dropdown"}}
                                 </div>
                             </div>

--- a/rcjaRegistration/templates/eventfiles/uploadMentorEventFile.html
+++ b/rcjaRegistration/templates/eventfiles/uploadMentorEventFile.html
@@ -114,7 +114,7 @@
                             </div>
                             {% endif %}
 
-                            <div class="field">
+                            <div style="display: none" class="field">
                                 <label>Comments:</label>
                                 {{form.comments}}
                             </div>


### PR DESCRIPTION
The file comments field is being used poorly, and most people with a share link are putting it in a document and uploading this anyway.

This will now be the only supported method for providing share links. 