### PR TITLE
RC - 797 - Remove notes & DOB fields from mentors view

### DIFF
--- a/rcjaRegistration/templates/eventfiles/uploadMentorEventFile.html
+++ b/rcjaRegistration/templates/eventfiles/uploadMentorEventFile.html
@@ -47,7 +47,7 @@
 
                         {% if not uploadedFile %}
                         <h2>Upload a new file</h2>
-                        <h3 style="color: red">Due to an issue files larger than approximately 10MB currently cannot be uploaded. For larger files please instead submit a sharing link through the notes field on the team.<br/><br/>If you wish to submit a sharing link, please upload a Word or Notepad file with the sharing link inside.</h3>
+                        <h3 style="color: red">Due to an issue files larger than approximately 10MB currently cannot be uploaded. For larger files please instead submit a sharing link.<br/><br/>If you wish to submit a sharing link, please upload a Word or Notepad file with the sharing link inside. Ensure the sharing is set to public.</h3>
 
                         {% else %}
                         <h2>Edit existing file: <a href="{{uploadedFile.fileURL}}" target="_blank">{{uploadedFile.originalFilename}}</a></h2>

--- a/rcjaRegistration/templates/teams/createEditTeam.html
+++ b/rcjaRegistration/templates/teams/createEditTeam.html
@@ -93,7 +93,7 @@
                     {{ form.campus|attr:"class:ui dropdown"}} 
                 </div>
               </div>
-              <div class = "field">
+              <div style="display: none" class = "field">
                 <label>Notes:</label>
                   {{ form.notes|attr:"rows:2"}} 
               </div>

--- a/rcjaRegistration/templates/teams/details.html
+++ b/rcjaRegistration/templates/teams/details.html
@@ -57,7 +57,6 @@
                 <thead>
                     <th>Name</th>
                     <th>Year Level</th>
-                    <th>Birthday</th>
                     <th>Gender</th>
                 </thead>
                 <tbody>
@@ -65,7 +64,6 @@
                     <tr id="studentRow{{student.id}}">
                         <td>{{student}}</td>
                         <td>{{student.yearLevel}}</td>
-                        <td>{{student.birthday}}</td>
                         <td>{{student.get_gender_display}}</td>
                     </tr>
                     {% endfor %}

--- a/rcjaRegistration/templates/teams/studentForm.html
+++ b/rcjaRegistration/templates/teams/studentForm.html
@@ -33,9 +33,9 @@
         {{studentform.yearLevel}}
             
       </div>
-      <div class="field">
+      <div style="display: none" class="field">
         {{studentform.birthday.label_tag}}
-        {{studentform.birthday|attr:"type:date"|attr:"placeholder:yyyy-mm-dd"}}
+        {{studentform.birthday|attr:"type:date"|attr:"placeholder:yyyy-mm-dd"|attr:"value:1970-01-01"}}
             
       </div>
       <div class="field">

--- a/rcjaRegistration/templates/workshops/createEditAttendee.html
+++ b/rcjaRegistration/templates/workshops/createEditAttendee.html
@@ -123,9 +123,9 @@
                 </div>
               </div>
               <div id="studentOnlyFields"style="display:none">
-                <div class = "field">
+                <div style="display: none" class = "field">
                   <label>Birthday:</label>
-                    {{form.birthday|attr:"type:date"|attr:"id:birthdayForm"|attr:"placeholder:yyyy-mm-dd"}}
+                    {{form.birthday|attr:"type:date"|attr:"id:birthdayForm"|attr:"placeholder:yyyy-mm-dd"|attr:"value:1970-01-01"}}
                 </div>
               </div>
 


### PR DESCRIPTION
The notes field is poorly used, and the use we have for DOB does not warrant the risk associated with collecting it.

This hides the two fields for mentors, defaulting the DOB to 1/1/1970. 

Once this is implemented, the DOBs need to be scrubbed from the DB. 