### PR TITLE
Add team creation date to admin table/export

### DIFF
--- a/rcjaRegistration/teams/admin.py
+++ b/rcjaRegistration/teams/admin.py
@@ -43,6 +43,7 @@ class StudentInline(InlineAdminPermissions, admin.TabularInline):
 @admin.register(Team)
 class TeamAdmin(BaseWorkshopAttendanceAdmin):
     list_display = [
+        'creationDateTime',
         'name',
         'event',
         'division',
@@ -100,6 +101,7 @@ class TeamAdmin(BaseWorkshopAttendanceAdmin):
         'export_as_csv'
     ]
     exportFields = [
+        'creationDateTime',
         'pk',
         'name',
         'event',

--- a/rcjaRegistration/teams/admin.py
+++ b/rcjaRegistration/teams/admin.py
@@ -43,10 +43,10 @@ class StudentInline(InlineAdminPermissions, admin.TabularInline):
 @admin.register(Team)
 class TeamAdmin(BaseWorkshopAttendanceAdmin):
     list_display = [
-        'creationDateTime',
         'name',
         'event',
         'division',
+        'creationDateTime',
         'mentorUserName',
         'school',
         'campus',
@@ -63,7 +63,12 @@ class TeamAdmin(BaseWorkshopAttendanceAdmin):
             'fields': ('mentorUser', 'school', 'campus',)
         }),
         ('Details', {
-            'fields': ('hardwarePlatform', 'softwarePlatform',)
+            'fields': (
+                'hardwarePlatform',
+                'softwarePlatform',
+                'creationDateTime',
+                'updatedDateTime',
+            )
         }),
     )
     add_fieldsets = (
@@ -81,6 +86,11 @@ class TeamAdmin(BaseWorkshopAttendanceAdmin):
             'fields': ('hardwarePlatform', 'softwarePlatform',)
         }),
     )
+
+    readonly_fields = [
+        'creationDateTime',
+        'updatedDateTime',
+    ]
 
     inlines = [
         StudentInline
@@ -102,6 +112,7 @@ class TeamAdmin(BaseWorkshopAttendanceAdmin):
     ]
     exportFields = [
         'creationDateTime',
+        'updatedDateTime',
         'pk',
         'name',
         'event',


### PR DESCRIPTION
This will add the creation date/time to the teams admin table & the csv export. This allows you to sort by team add date, to see the recently added teams.