### PR TITLE
Add Sentry Error Monitoring

### DIFF
--- a/rcjaRegistration/rcjaRegistration/settings.py
+++ b/rcjaRegistration/rcjaRegistration/settings.py
@@ -14,6 +14,7 @@ import os
 import environ
 import sys
 from opencensus.trace import config_integration
+import sentry_sdk
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -321,3 +322,21 @@ PRIVATE_DOMAIN = f'{PRIVATE_BUCKET}.s3.amazonaws.com'
 AWS_PRIVATE_MEDIA_LOCATION = ''
 
 DEFAULT_FILE_STORAGE = 'rcjaRegistration.storageBackends.PrivateMediaStorage'
+
+if not DEV_SETTINGS:
+    sentry_sdk.init(
+        dsn='SENTRY_DSN',
+        enable_tracing=False,
+        sample_rate=1.0,
+        send_default_pii=False,
+        enrionment='production',
+        integrations=[
+            DjangoIntegration(
+                transaction_style='url',
+                middleware_spans=True,
+                signals_spans=False,
+                cache_spans=False,
+            ),
+        ]
+    )
+

--- a/rcjaRegistration/rcjaRegistration/settings.py
+++ b/rcjaRegistration/rcjaRegistration/settings.py
@@ -15,6 +15,7 @@ import environ
 import sys
 from opencensus.trace import config_integration
 import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/rcjaRegistration/rcjaRegistration/settings.py
+++ b/rcjaRegistration/rcjaRegistration/settings.py
@@ -31,6 +31,8 @@ env = environ.Env(
     STATIC_BUCKET=(str, 'STATIC_BUCKET'),
     PUBLIC_BUCKET=(str, 'PUBLIC_BUCKET'),
     PRIVATE_BUCKET=(str, 'PRIVATE_BUCKET'),
+    SENTRY_DSN = (str, 'SENTRY_DSN'),
+    SENTRY_ENV = (str, 'production'),
     DEV_SETTINGS=(bool, False),
     DEFAULT_FROM_EMAIL=(str, 'entersupport@robocupjunior.org.au'),
     APPLICATIONINSIGHTS_CONNECTION_STRING=(str, '')
@@ -324,17 +326,19 @@ AWS_PRIVATE_MEDIA_LOCATION = ''
 
 DEFAULT_FILE_STORAGE = 'rcjaRegistration.storageBackends.PrivateMediaStorage'
 
-if not DEV_SETTINGS:
+
+SENTRY_DSN = env('SENTRY_DSN')
+if SENTRY_DSN != 'SENTRY_DSN':
     sentry_sdk.init(
-        dsn='SENTRY_DSN',
+        dsn=SENTRY_DSN,
+        environment=env('SENTRY_ENV'),
         enable_tracing=False,
         sample_rate=1.0,
-        send_default_pii=False,
-        enrionment='production',
+        send_default_pii=True,
         integrations=[
             DjangoIntegration(
                 transaction_style='url',
-                middleware_spans=True,
+                middleware_spans=False,
                 signals_spans=False,
                 cache_spans=False,
             ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.7.2
 bleach==6.0.0
 boto3==1.28.38
 botocore==1.31.38
-certifi==2023.7.22
+certifi==2023.11.17
 chardet==5.2.0
 Django==4.2.7
 django-appconf==1.0.4
@@ -24,6 +24,7 @@ python-dateutil==2.8.1
 pytz==2020.1
 requests==2.31.0
 s3transfer==0.6.2
+sentry-sdk==1.39.2
 six==1.15.0
 sqlparse==0.4.4
 uritemplate==3.0.1


### PR DESCRIPTION
As we have a Sentry subscription, we should utilise this for the rego system. 

This will be especially useful for correlating emails from mentors reporting issues, with what went wrong, and identifying the cause of various other transient errors. 