### PR TITLE
Add All filter to year dropdown & Move filter dropdowns to admin nav

### DIFF
--- a/rcjaRegistration/templates/admin/base_site.html
+++ b/rcjaRegistration/templates/admin/base_site.html
@@ -7,8 +7,55 @@
 {% endblock %}
 
 {% block branding %}
-<h1 id="site-name"><a href="{% url 'admin:index' %}">
-     <img src="{% static 'favicon-32x32.png' %}">
-    {{ site_header|default:_('Django administration') }}
-    </a></h1>
+    <div style="display: flex; gap: 20px; flex-wrap: wrap; align-items: center">
+        <h1 id="site-name" style="margin: 0; display: flex; align-items: center; flex-wrap: wrap; text-wrap: nowrap">
+            <a href="{% url 'admin:index' %}">
+                <img src="{% static 'favicon-32x32.png' %}">
+                {{ site_header|default:_('Django administration') }}
+            </a>
+        </h1>
+
+        <div style="display: flex; gap: 20px; flex-wrap: wrap; align-items: center; justify-content: flex-end">
+            <form method="post">
+                {% csrf_token %}
+                <select name="year_filter" onchange="this.form.action = this.value; this.form.submit()" style="margin: 0; width: 120px">
+                    {% if not user.currentlySelectedAdminYear %}
+                        <option value disabled selected>Filter by Year</option>
+                    {% else %}
+                        <option value disabled>Filter by Year</option>
+                        <option value selected style="display: none">Year: {{ user.currentlySelectedAdminYear }}</option>
+                    {% endif %}
+                    <option value="{% url 'users:setCurrentAdminYear' 0 %}">All</option>
+        
+                    {% for year in years %}
+                        <option value="{% url 'users:setCurrentAdminYear' year %}">{{ year }}</option>
+                    {% endfor %}
+                </select>
+            </form>
+        
+            {% if user.adminViewableStates|length > 1 %}
+                <form method="post">
+                    {% csrf_token %}
+                    <select name="state_filter" onchange="this.form.action = this.value; this.form.submit()" style="margin: 0; width: 120px">
+                        {% if not user.currentlySelectedAdminState %}
+                            <option value disabled selected>Filter by State</option>
+                        {% else %}
+                            <option value disabled>Filter by State</option>
+                            <option value selected style="display: none">State: {{ user.currentlySelectedAdminState.abbreviation }}</option>
+                        {% endif %}
+                        <option value="{% url 'users:setCurrentAdminState' 0 %}">All</option>
+        
+                        {% for state in user.adminViewableStates %}
+                            <option value="{% url 'users:setCurrentAdminState' state.id %}">{{ state.name }}</option>
+                        {% endfor %}
+                    </select>
+                </form>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}
+
+{% block welcome-msg %}
+    Welcome, 
+    <strong>{% firstof user.get_full_name user.get_username %}</strong>.
 {% endblock %}

--- a/rcjaRegistration/templates/common/loggedInbase.html
+++ b/rcjaRegistration/templates/common/loggedInbase.html
@@ -133,7 +133,7 @@
                     </div>
                 </div>
             {% endif %}
-            {% if user.is_staff %}
+            {% if user.is_staff and user.adminViewableStates|length > 1 %}
                 <div class="ui dropdown simple item" >
                     <span style="width:3.3em; overflow: hidden; text-overflow: ellipsis;">
                     {% if user.currentlySelectedAdminState in user.adminViewableStates %}

--- a/rcjaRegistration/templates/common/loggedInbase.html
+++ b/rcjaRegistration/templates/common/loggedInbase.html
@@ -120,6 +120,10 @@
                     </span>
                     <i class="dropdown icon"></i>
                     <div class="menu">
+                        <form method="post" action="{% url 'users:setCurrentAdminYear' 0 %}" class="button-form">
+                            {% csrf_token %}
+                            <input class="header-button item" type="submit" value="All"/>
+                        </form>
                         {% for year in years %}
                             <form method="post" action="{% url 'users:setCurrentAdminYear' year.year %}" class="button-form">
                                 {% csrf_token %}

--- a/rcjaRegistration/templates/common/loggedInbase.html
+++ b/rcjaRegistration/templates/common/loggedInbase.html
@@ -110,54 +110,6 @@
         </div>
         <div class = "right menu">
             {% if user.is_staff %}
-                <div class="ui dropdown simple item" >
-                    <span style="width:3.3em; overflow: hidden; text-overflow: ellipsis;">
-                    {% if user.currentlySelectedAdminYear %}
-                    {{ user.currentlySelectedAdminYear }}
-                    {% else %}
-                    Year
-                    {% endif %}
-                    </span>
-                    <i class="dropdown icon"></i>
-                    <div class="menu">
-                        <form method="post" action="{% url 'users:setCurrentAdminYear' 0 %}" class="button-form">
-                            {% csrf_token %}
-                            <input class="header-button item" type="submit" value="All"/>
-                        </form>
-                        {% for year in years %}
-                            <form method="post" action="{% url 'users:setCurrentAdminYear' year.year %}" class="button-form">
-                                {% csrf_token %}
-                                <input class="header-button item" type="submit" value="{{ year }}"/>
-                            </form>
-                        {% endfor %}
-                    </div>
-                </div>
-            {% endif %}
-            {% if user.is_staff and user.adminViewableStates|length > 1 %}
-                <div class="ui dropdown simple item" >
-                    <span style="width:3.3em; overflow: hidden; text-overflow: ellipsis;">
-                    {% if user.currentlySelectedAdminState in user.adminViewableStates %}
-                    {{ user.currentlySelectedAdminState.abbreviation }}
-                    {% else %}
-                    State
-                    {% endif %}
-                    </span>
-                    <i class="dropdown icon"></i>
-                    <div class="menu">
-                        <form method="post" action="{% url 'users:setCurrentAdminState' 0 %}" class="button-form">
-                            {% csrf_token %}
-                            <input class="header-button item" type="submit" value="All States"/>
-                        </form>
-                        {% for state in user.adminViewableStates %}
-                            <form method="post" action="{% url 'users:setCurrentAdminState' state.id %}" class="button-form">
-                                {% csrf_token %}
-                                <input class="header-button item" type="submit" value="{{ state }}"/>
-                            </form>
-                        {% endfor %}
-                    </div>
-                </div>
-            {% endif %}
-            {% if user.is_staff %}
             <a class="item" href="{% url 'admin:index' %}" style="max-width:48%" >
                 <i class="id badge icon"></i>
                 Admin

--- a/rcjaRegistration/templates/common/loggedInbase.html
+++ b/rcjaRegistration/templates/common/loggedInbase.html
@@ -136,9 +136,7 @@
             {% if user.is_staff %}
                 <div class="ui dropdown simple item" >
                     <span style="width:3.3em; overflow: hidden; text-overflow: ellipsis;">
-                    {% if user.currentlySelectedAdminState is None %}
-                    All
-                    {% elif user.currentlySelectedAdminState in user.adminViewableStates %}
+                    {% if user.currentlySelectedAdminState in user.adminViewableStates %}
                     {{ user.currentlySelectedAdminState.abbreviation }}
                     {% else %}
                     State

--- a/rcjaRegistration/users/tests/test_views.py
+++ b/rcjaRegistration/users/tests/test_views.py
@@ -122,13 +122,15 @@ class Test_response_setCurrentAdminYear(TestCase):
         self.user_state1_fullcoordinator.refresh_from_db()
         self.assertEqual(self.user_state1_fullcoordinator.currentlySelectedAdminYear, None)
 
-    def testNone404(self):
-        self.assertEqual(self.user_state1_fullcoordinator.currentlySelectedAdminYear, None)
+    def testNoneSuccess(self):
+        self.user_state1_fullcoordinator.currentlySelectedAdminYear = self.year
+        self.user_state1_fullcoordinator.save()
+        self.assertEqual(self.user_state1_fullcoordinator.currentlySelectedAdminYear, self.year)
 
         response = self.client.post(reverse('users:setCurrentAdminYear', kwargs= {'year':0}))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 302)
 
-        # Check no update to value
+        # Check updated
         self.user_state1_fullcoordinator.refresh_from_db()
         self.assertEqual(self.user_state1_fullcoordinator.currentlySelectedAdminYear, None)
 

--- a/rcjaRegistration/users/views.py
+++ b/rcjaRegistration/users/views.py
@@ -122,11 +122,17 @@ def setCurrentAdminYear(request, year):
     if not request.user.is_staff:
         raise PermissionDenied("Must be staff")
 
-    from events.models import Year
-    year = get_object_or_404(Year, pk=year)
+    if year == 0:
+        request.user.currentlySelectedAdminYear = None
 
-    # Set current year on user
-    request.user.currentlySelectedAdminYear = year
+    else:
+        from events.models import Year
+        year = get_object_or_404(Year, pk=year)
+
+        # Set current year on user
+        request.user.currentlySelectedAdminYear = year
+
+    # Save field
     request.user.save(update_fields=['currentlySelectedAdminYear'])
     
     return redirectCurrentPage(request)
@@ -144,7 +150,6 @@ def setCurrentAdminState(request, stateID):
         request.user.currentlySelectedAdminState = None
 
     else:
-
         from regions.models import State
         state = get_object_or_404(State, pk=stateID)
 


### PR DESCRIPTION
I've pulled out @peter-drew's fixes for #639 from #640 and left the one disabling student editing which might need more thought

Additionally, I moved the year and state filters into the admin menus both for convenience and since it makes more sense for them to be there, as that's all they affect

The state filter now also only shows when a user has access to more than 1 state

![image](https://github.com/robocupjunioraustralia/RCJA_Registration_System/assets/36472285/599457af-fadf-4224-b1a8-f9f546b3dcc1)
