### PR TITLE
Add ability for app to be behind a reverse proxy

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,10 @@
+DATABASE_URL=postgres://rcjaregistration:abc123@db/registration
+DEV_SETTINGS=true
+DEBUG=true
+DJANGO_LOG_LEVEL=DEBUG
+SECRET_KEY=TESTONLY_slfgdjheaklfgjb34wuhgb35789gbne97urgblskdg # Any random string
+
+# For database, if running locally
+POSTGRES_DB=registration
+POSTGRES_USER=rcjaregistration
+POSTGRES_PASSWORD=abc123

--- a/.env.dev.sample
+++ b/.env.dev.sample
@@ -1,0 +1,10 @@
+DATABASE_URL=postgres://rcjaregistration:abc123@db/registration
+DEV_SETTINGS=true
+DEBUG=true
+DJANGO_LOG_LEVEL=DEBUG
+SECRET_KEY=TESTONLY_slfgdjheaklfgjb34wuhgb35789gbne97urgblskdg # Any random string
+
+# For database, if running locally
+POSTGRES_DB=registration
+POSTGRES_USER=rcjaregistration
+POSTGRES_PASSWORD=abc123

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,22 @@
+ALLOWED_HOSTS=enter.robocupjunior.org.au,enter.rcja.app
+AWS_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXXXXXX
+AWS_SECRET_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXXXX
+DATABASE_URL=postgres://rcjaregistration:XXXXXXXXXXXXXXXXXXXXXX@db/registration
+DEBUG=false
+DEFAULT_FROM_EMAIL=entersupport@robocupjunior.org.au
+DEV_SETTINGS=false
+USE_PROXY=False
+USE_SQLLITE_DB=False
+PRIVATE_BUCKET=rcjaregistration-prod-private
+PUBLIC_BUCKET=rcjaregistration-prod-public
+SECRET_KEY=XXXXXXXXXXXXXXXXXXXXXX
+SENDGRID_API_KEY=XXXXXXXXXXXXXXXXXXXXXX
+SENTRY_ENV=production
+SENTRY_DSN=https://XXXXXXXXXXXXXXXXXXXXXX@XXXXXXXXXXXXXXXXXXXXXX.ingest.sentry.io/XXXXXXXXXXXXXXXXXXXXXX
+STATIC_BUCKET=rcjaregistration-prod-static
+#STATIC_ROOT= # Leave unset for BASE_DIR/static
+
+# For database, if running locally
+POSTGRES_DB=registration
+POSTGRES_USER=rcjaregistration
+POSTGRES_PASSWORD=XXXXXXXXXXXXXXXXXXXXXX

--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -9,6 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Get environment variables
+      run: |
+        cp .env.ci .env
     - name: Set up Docker Compose stack
       run: |
         docker-compose up -d

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -7,8 +7,6 @@ services:
     build: .
     ports:
       - 8000:8000
-    environment:
-      - DEBUG=false
-      - SECRET_KEY
+
   db:
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,19 +2,16 @@ version: '3'
 
 services:
   web:
-    environment:
-      - DATABASE_URL=postgres://rcjaRegistration:abc123@db/rcjaRegistration
-      - DEV_SETTINGS=true
+    env_file:
+      - .env
     depends_on:
       - db
   db:
-    image: postgres:alpine
+    image: postgres:14.11
     volumes:
       - postgres_data:/var/lib/postgresql/data/
-    environment:
-      - POSTGRES_DB=rcjaRegistration
-      - POSTGRES_USER=rcjaRegistration
-      - POSTGRES_PASSWORD=abc123
+    env_file:
+      - .env
 
 volumes:
   postgres_data:


### PR DESCRIPTION
After the move to the rcja.app server, the rego sys was put behind a reverse proxy, leading to absolute URLs linking to 127.0.0.1

This is now fixed, and I also added all the required environment files to some sample .env files so that it's easier to understand what is needed when setting up the system.