### PR TITLE
Fix paidEvent check for workshops

### DIFF
--- a/rcjaRegistration/events/models.py
+++ b/rcjaRegistration/events/models.py
@@ -413,6 +413,12 @@ class Event(SaveDeleteMixin, models.Model):
     def paidEvent(self):
         if self.event_defaultEntryFee > 0 or (self.event_specialRateFee and self.event_specialRateFee > 0):
             return True
+        # Workshops don't rely on the default entry fee
+        if self.eventType == 'workshop':
+            if self.workshopTeacherEntryFee and self.workshopTeacherEntryFee > 0:
+                return True
+            if self.workshopStudentEntryFee and self.workshopStudentEntryFee > 0:
+                return True
 
         return self.availabledivision_set.filter(division_entryFee__gt=0).exists()
 

--- a/rcjaRegistration/events/tests/tests_legacy.py
+++ b/rcjaRegistration/events/tests/tests_legacy.py
@@ -757,6 +757,18 @@ class TestEventMethods(TestCase):
 
         self.assertTrue(self.event.paidEvent())
 
+    def testPaidEvent_workshop_studentEntryFee(self):
+        self.event.eventType = 'workshop'
+        self.event.event_defaultEntryFee = 0
+        self.event.workshopStudentEntryFee = 5
+        self.assertTrue(self.event.paidEvent())
+
+    def testPaidEvent_workshop_teacherEntryFee(self):
+        self.event.eventType = 'workshop'
+        self.event.event_defaultEntryFee = 0
+        self.event.workshopTeacherEntryFee = 5
+        self.assertTrue(self.event.paidEvent())
+
     def test_published_draft(self):
         self.event.status = 'draft'
         self.assertFalse(self.event.published())


### PR DESCRIPTION
Invoices weren't being generated for workshops. Because `event_defaultEntryFee` defaults to 0 for workshops, it was marking workshops as free.

This adjusts to check teacher and student entry fees if it's a workshop.
