### PR TITLE
Fix django tests: Use docker compose V2

### DIFF
--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -14,25 +14,25 @@ jobs:
         cp .env.ci .env
     - name: Set up Docker Compose stack
       run: |
-        docker-compose up -d
+        docker compose up -d
     - name: Install test dependencies
       run: |
-        docker-compose exec -T web pip install flake8 coverage
+        docker compose exec -T web pip install flake8 coverage
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        docker-compose exec -T web flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        docker compose exec -T web flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        docker-compose exec -T web flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        docker compose exec -T web flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        docker-compose exec -T web coverage run --source='.' manage.py test --settings=rcjaRegistration.settings_test
+        docker compose exec -T web coverage run --source='.' manage.py test --settings=rcjaRegistration.settings_test
         #pip install pytest
         #pytest
     - name: Generate code coverage report
       run: |
-        docker-compose exec -T web coverage report
-        docker-compose exec -T web coverage xml
+        docker compose exec -T web coverage report
+        docker compose exec -T web coverage xml
     - uses: codecov/codecov-action@v3
       with:
         token: ${{secrets.CODECOV_TOKEN}} #required
@@ -41,4 +41,4 @@ jobs:
         name: codecov-umbrella #optional
     - name: Tear down Docker Compose stack
       run: |
-        docker-compose down
+        docker compose down

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     image: rcja-registration:development

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     env_file:


### PR DESCRIPTION
Fixes the django tests, just needed to migrate to docker compose V2 as per https://github.com/actions/runner-images/issues/9557