### PR TITLE
Add withdrawn field to team view in admin & team csv export

### DIFF
--- a/rcjaRegistration/teams/admin.py
+++ b/rcjaRegistration/teams/admin.py
@@ -51,6 +51,7 @@ class TeamAdmin(BaseWorkshopAttendanceAdmin):
         'school',
         'campus',
         'homeState',
+        'withdrawn',
     ]
     fieldsets = (
         (None, {
@@ -116,6 +117,7 @@ class TeamAdmin(BaseWorkshopAttendanceAdmin):
         'updatedDateTime',
         'pk',
         'name',
+        'withdrawn',
         'event',
         'division',
         'mentorUserName',


### PR DESCRIPTION
After the withdrawn field was added in #670, there was no way to see this in the UI except for the team edit page, or from the mentors point of view.

It now shows on the team admin page, and it also shows in the CSV export of teams.
![image](https://github.com/user-attachments/assets/df32195d-52de-4b59-9e98-05b9297620d6)

![image](https://github.com/user-attachments/assets/b35bc671-5376-4b0b-8c26-0dc62a5bff78)
 