### PR TITLE
Association Members - Add approval status to CSV export

### DIFF
--- a/rcjaRegistration/association/admin.py
+++ b/rcjaRegistration/association/admin.py
@@ -90,6 +90,7 @@ class SchoolAdmin(FKActionsRemove, AdminPermissions, admin.ModelAdmin, ExportCSV
         'address',
         'membershipActive',
         'membershipType',
+        'approvalStatus',
         'membershipStartDate',
         'membershipEndDate',
     ]


### PR DESCRIPTION
Resolves #788 

---

The approval status is now available within the CSV export for association members

<img width="664" height="168" alt="image" src="https://github.com/user-attachments/assets/c7f28484-64b9-461f-9b4d-cbb8bf014fd1" />
